### PR TITLE
The application was failing on resource-constrained environments due …

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ app = FastAPI()
 
 # Download a multi-speaker TTS model first
 # e.g.: TTS --list_models
-model_name = "tts_models/en/ljspeech/tacotron2-DDC"
+model_name = "tts_models/en/vctk/vits"
 
 # Loading the TTS
 tts = TTS(model_name)
@@ -20,6 +20,6 @@ def synthesize(text: str = Form(...)):
     file_name = f"{uuid.uuid4()}.wav"
     file_path = os.path.join("/tmp", file_name)
 
-    tts.tts_to_file(text=text, file_path=file_path)
+    tts.tts_to_file(text=text, file_path=file_path, speaker="p225")
 
     return FileResponse(file_path, media_type='audio/wav', filename=file_name)

--- a/services/tts_service.py
+++ b/services/tts_service.py
@@ -6,7 +6,7 @@ from TTS.api import TTS
 
 class TTSService:
     def __init__(self):
-        self.model_name = "tts_models/en/ljspeech/tacotron2-DDC"
+        self.model_name = "tts_models/en/vctk/vits"
         self.language = "en"
 
         self.tts = TTS(self.model_name)
@@ -26,7 +26,7 @@ class TTSService:
         file_name = f"{uuid.uuid4()}.wav"
         file_path = os.path.join(self.output_dir, file_name)
         
-        self.tts.tts_to_file(text=text, file_path=file_path)
+        self.tts.tts_to_file(text=text, file_path=file_path, speaker="p225")
         
         return file_path
     


### PR DESCRIPTION
…to the large memory footprint of the tacotron2-DDC TTS model.

This change replaces the default model with the more memory-efficient vits model (`tts_models/en/vctk/vits`).

Additionally, it provides a default speaker ID ('p225') to the synthesis function, as the new multi-speaker model requires it.