### PR TITLE
This commit resolves two critical memory issues that prevented the ap…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+--index-url https://download.pytorch.org/whl/cpu
+torch==2.3.1
+torchaudio==2.3.1
 fastapi==0.112.0
 uvicorn==0.30.6
 coqui-tts==0.25.3


### PR DESCRIPTION
…plication from running on resource-constrained environments like Render's free tier.

1.  **Build-time Memory Error:** The build was failing with an out-of-memory error because `pip` was attempting to compile PyTorch from source. This is fixed by modifying `requirements.txt` to use a pre-compiled, CPU-only version of PyTorch from its official package index.

2.  **Runtime Memory Error:** The `tacotron2-DDC` model was too large for the runtime environment. This is fixed by replacing it with the lightweight `vits` model and providing a default speaker ID, as required.